### PR TITLE
bump iterio-server version

### DIFF
--- a/hails-auth.cabal
+++ b/hails-auth.cabal
@@ -26,7 +26,7 @@ Executable hails-auth
                  bytestring >= 0.9 && < 1,
                  containers >= 0.4.2 && < 0.5,
                  iterIO >= 0.2.2 && < 0.3,
-                 iterio-server >= 0.3 && < 0.4,
+                 iterio-server >= 0.3.1 && < 0.4,
                  HsOpenSSL >= 0.10.1 && < 2,
                  mongoDB >= 1.1.2 && < 1.3,
                  structured-mongoDB >= 0.3 && < 1.0,


### PR DESCRIPTION
the Data.List.Split module also isn't safe but is imported with a safe import, so this still doesn't get it compiling but up to you what to do about that.
